### PR TITLE
Casts ansible_lsb.major_release Type to int

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -18,7 +18,7 @@
     value: "{{ item.value }}"
   with_items:
     - { name: "net.ipv4.tcp_tw_recycle", value: 1 }
-  when: ansible_lsb.major_release < 18
+  when: ansible_lsb.major_release|int < 18
 
 - name: Update limits.conf limits
   lineinfile:


### PR DESCRIPTION
Casts the type for the ansible_lsb.major_release variable to int to avoid
Ansible 2.8 from failing with a type comparison mismatch error.

Signed-off-by: Jason Rogena <jason@rogena.me>