### PR TITLE
Ensure `nf_conntrack` module is loaded before updating settings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,9 @@
 ---
+- name: Ensure nf_conntrack kernel module is loaded
+  modprobe:
+    name: nf_conntrack
+    state: present
+
 - name: Update sysctl net settings
   sysctl:
     name: "{{ item.name }}"
@@ -9,7 +14,7 @@
     - { name: "net.core.rmem_max", value: 16777216 }
     - { name: "net.core.wmem_max", value: 16777216 }
     - { name: "net.ipv4.ip_local_port_range", value: "10000 65535"}
-    - { name: "net.ipv4.netfilter.nf_conntrack_tcp_timeout_time_wait", value: "1"}
+    - { name: "net.netfilter.nf_conntrack_tcp_timeout_time_wait", value: "1"}
     - { name: "net.ipv4.tcp_rmem", value: "4096 87380 16777216" }
     - { name: "net.ipv4.tcp_wmem", value: "4096 16384 16777216" }
     - { name: "net.ipv4.tcp_fin_timeout", value: "15" }


### PR DESCRIPTION
# Changes

- Ensure `nf_conntrack` is loaded before updating settings
- Update `nf_conntrack_tcp_timeout_time_wait` "name" value to `net.netfilter.nf_conntrack_tcp_timeout_time_wait`