### PR TITLE
Load `ip_conntrack` kernel module before updating sysctl net settings

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,8 +1,11 @@
 ---
-- name: Ensure nf_conntrack kernel module is loaded
+- name: Load kernel modules
   modprobe:
-    name: nf_conntrack
+    name: "{{ item }}"
     state: present
+  with_items:
+    - nf_conntrack
+    - ip_conntrack
 
 - name: Update sysctl net settings
   sysctl:


### PR DESCRIPTION
## Fixes

![Screenshot from 2020-08-18 13-05-06](https://user-images.githubusercontent.com/20133492/90509041-64f3d480-e161-11ea-924f-036a94d38d3d.png)
