### PR TITLE
Fixes linux_config_noatime_srcs Rendering

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -61,5 +61,4 @@
     fstype: ext4
     opts: rw,noatime
     state: mounted
-  with_items:
-    - linux_config_noatime_srcs
+  with_items: "{{ linux_config_noatime_srcs }}"


### PR DESCRIPTION
Fix issue causing linux_config_noatime_srcs not to be rendered correctly
when applied on a host. The string "linux_config_noatime_srcs" is copied
into /etc/fstab instead of the values in the list.

Signed-off-by: Jason Rogena <jason@rogena.me>